### PR TITLE
Change timestamps to u64

### DIFF
--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -42,8 +42,8 @@ builder!{Activity
 }
 
 builder!{ActivityTimestamps
-    start: u32,
-    end: u32,
+    start: u64,
+    end: u64,
 }
 
 builder!{ActivityAssets


### PR DESCRIPTION
They are documented as u64: https://discordapp.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields