### PR TITLE
add support for setting activity type

### DIFF
--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -61,6 +61,7 @@ builder!{Activity
     assets: ActivityAssets func,
     party: ActivityParty func,
     secrets: ActivitySecrets func,
+    r#type: u8,
 }
 
 builder!{ActivityTimestamps


### PR DESCRIPTION
Allows setting the activity type to Streaming, Listening, Watching, Custom, and Competing.

https://discord.com/developers/docs/events/gateway-events#activity-object-activity-types